### PR TITLE
Added initial docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM php:7-alpine
+MAINTAINER Pandry <togniand@gmail.com>
+
+WORKDIR /app
+COPY . /app
+
+#        sed -i s/DB_CONNECTION=mysql/DB_CONNECTION=pgsql/ .env && \
+#        sed -i s/DB_PORT=3306/DB_PORT=5432/ .env && \
+
+RUN apk add --no-cache --update openssl zip unzip oniguruma-dev zlib-dev libpng-dev libzip-dev postgresql-dev && \
+        curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
+        docker-php-ext-install pdo mbstring gd exif zip sockets  pdo_mysql   pgsql pdo_pgsql 
+
+RUN        cp .env.example .env && \
+        \
+        sed -i s/DB_HOST=127.0.0.1/DB_HOST=mariadb/ .env && \
+        sed -i s/REDIS_HOST=127.0.0.1/REDIS_HOST=redis/ .env && \
+        sed -i s/APP_ENV=local/APP_ENV=production/ .env && \
+        sed -i s/APP_DEBUG=true/APP_DEBUG=false/ .env && \
+	\
+        composer install --no-dev -o && \
+	php artisan optimize && \
+	php artisan view:clear && \
+        \
+        php artisan key:generate && \
+        php artisan storage:link && \
+	php artisan config:cache && \
+        php artisan migrate --seed 
+
+#RUN composer install
+
+CMD php artisan serve --host=0.0.0.0 --port=80
+EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,30 +4,28 @@ MAINTAINER Pandry <togniand@gmail.com>
 WORKDIR /app
 COPY . /app
 
-#        sed -i s/DB_CONNECTION=mysql/DB_CONNECTION=pgsql/ .env && \
-#        sed -i s/DB_PORT=3306/DB_PORT=5432/ .env && \
-
 RUN apk add --no-cache --update openssl zip unzip oniguruma-dev zlib-dev libpng-dev libzip-dev postgresql-dev && \
         curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
-        docker-php-ext-install pdo mbstring gd exif zip sockets  pdo_mysql   pgsql pdo_pgsql 
-
-RUN        cp .env.example .env && \
+        docker-php-ext-install pdo mbstring gd exif zip sockets  pdo_mysql   pgsql pdo_pgsql && \
+        cp .env.example .env && \
         \
         sed -i s/DB_HOST=127.0.0.1/DB_HOST=mariadb/ .env && \
         sed -i s/REDIS_HOST=127.0.0.1/REDIS_HOST=redis/ .env && \
         sed -i s/APP_ENV=local/APP_ENV=production/ .env && \
         sed -i s/APP_DEBUG=true/APP_DEBUG=false/ .env && \
-	\
+        sed -i s/CACHE_DRIVER=file/CACHE_DRIVER=redis/ .env && \
+        sed -i s/QUEUE_CONNECTION=sync/QUEUE_CONNECTION=redis/ .env && \
+        sed -i s/SESSION_DRIVER=file/SESSION_DRIVER=redis/ .env && \
+        sed -i s/REDIS_HOST=127.0.0.1/REDIS_HOST=redis/ .env && \
+        \
         composer install --no-dev -o && \
-	php artisan optimize && \
-	php artisan view:clear && \
+        php artisan optimize && \
+        php artisan view:clear && \
         \
         php artisan key:generate && \
         php artisan storage:link && \
-	php artisan config:cache && \
+        php artisan config:cache && \
         php artisan migrate --seed 
-
-#RUN composer install
 
 CMD php artisan serve --host=0.0.0.0 --port=80
 EXPOSE 80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,79 @@
+version: '2.2'
+services:
+  shaark:
+    image: shaark
+    build: .
+    container_name: shaark
+    restart: unless-stopped
+#    volumes:
+#      - "./env:/app/.env"
+#    ports:
+#      - "80:80/tcp"
+#      - "443:443/tcp"
+    networks:
+      - shaark
+      - nginx_net
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+#  postgres:
+#    image: postgres
+#    container_name: postgres_shaark
+#    restart: unless-stopped
+#    volumes:
+#      - /opt/shaark/postgres:/var/lib/postgresql/data
+#    networks:
+#      - shaark
+#    environment:
+#      POSTGRES_PASSWORD: secret
+#      POSTGRES_USER: homestead
+#      POSTGRES_DB: homestead
+#    logging:
+#      driver: "json-file"
+#      options:
+#        max-size: "10m"
+#        max-file: "5"
+ 
+  mariadb:     
+    image: mariadb
+    container_name: mariadb_shaark
+    restart: unless-stopped
+    volumes:
+      - /opt/shaark/mariadb:/var/lib/mysql
+    networks:
+      - shaark
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpassword9867ow3q459087w980
+      MYSQL_PASSWORD: secret
+      MYSQL_USER: homestead
+      MYSQL_DATABASE: homestead
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
+      
+
+  redis:
+    image: redis
+    container_name: redis_shaark
+    restart: unless-stopped
+    volumes:
+      - /opt/shaark/redis:/data
+    networks:
+      - shaark
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+
+networks:
+  shaark:
+    name: shaark_net
+  nginx_net:
+    name: nginx_net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
 #      - "./env:/app/.env"
 #    ports:
 #      - "80:80/tcp"
-#      - "443:443/tcp"
     networks:
       - shaark
       - nginx_net
@@ -18,25 +17,7 @@ services:
       options:
         max-size: "10m"
         max-file: "5"
-
-#  postgres:
-#    image: postgres
-#    container_name: postgres_shaark
-#    restart: unless-stopped
-#    volumes:
-#      - /opt/shaark/postgres:/var/lib/postgresql/data
-#    networks:
-#      - shaark
-#    environment:
-#      POSTGRES_PASSWORD: secret
-#      POSTGRES_USER: homestead
-#      POSTGRES_DB: homestead
-#    logging:
-#      driver: "json-file"
-#      options:
-#        max-size: "10m"
-#        max-file: "5"
- 
+        
   mariadb:     
     image: mariadb
     container_name: mariadb_shaark

--- a/documentation/docker.md
+++ b/documentation/docker.md
@@ -1,0 +1,21 @@
+# Shaark - Docker deployment
+Docker can be used to deploy Shaark.  
+By default it will install Shaark in production mode.  
+This behaviour can be changed by editing the Dockefile.  
+
+## Installation
+
+### Requirements
+At the moment the application needs to be in HTTPS since some srcs are in https (eg. js files) even if the site is in plain HTTP.  
+This should not be an issue if you already run some kind of reverse proxy, otherwise, you will need to run one and use a certificate (a self-signed one will be fine).  
+**NOTE**: you may (probably) need to customize the dockerfile (e.g. changing the network the container is attached at) to suit your case. (At least until the application will use HTTPS links)  
+
+### Quick Run
+You can try the application in minutes by running those commands:
+```
+git clone https://github.com/MarceauKa/shaark
+cd shaark
+docker-compose up -d .
+```
+And then running a reverse proxy like NGINX on the `nginx_net`.  
+If you don't already have a reverse proxy, you can google on how to create one.


### PR DESCRIPTION
Added initial support for docker
Since it is not possible to initialize the database, it is necessary to run `docker exec -it shaark php artisan migrate --seed` after the `docker-compose up -d` to successfully initialize the database.  
Also note that, for some reason, the application needs to be in HTTPS since some srcs are in https (eg. js files).  
Relates to #62 